### PR TITLE
fix: remove txs after execution in `DummyExecutor`

### DIFF
--- a/test/dummy_test.go
+++ b/test/dummy_test.go
@@ -1,9 +1,14 @@
 package test
 
 import (
+	"context"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/rollkit/go-execution/types"
 )
 
 type DummyTestSuite struct {
@@ -16,4 +21,38 @@ func (s *DummyTestSuite) SetupTest() {
 
 func TestDummySuite(t *testing.T) {
 	suite.Run(t, new(DummyTestSuite))
+}
+
+func TestTxRemoval(t *testing.T) {
+	exec := NewDummyExecutor()
+	tx1 := types.Tx([]byte{1, 2, 3})
+	tx2 := types.Tx([]byte{3, 2, 1})
+
+	exec.InjectTx(tx1)
+	exec.InjectTx(tx2)
+
+	// first execution of GetTxs - nothing special
+	txs, err := exec.GetTxs(context.Background())
+	require.NoError(t, err)
+	require.Len(t, txs, 2)
+	require.Contains(t, txs, tx1)
+	require.Contains(t, txs, tx2)
+
+	// ExecuteTxs was not called, so 2 txs should still be returned
+	txs, err = exec.GetTxs(context.Background())
+	require.NoError(t, err)
+	require.Len(t, txs, 2)
+	require.Contains(t, txs, tx1)
+	require.Contains(t, txs, tx2)
+
+	state, _, err := exec.ExecuteTxs(context.Background(), []types.Tx{tx1}, 1, time.Now(), nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, state)
+
+	// ExecuteTxs was called, 1 tx remaining in mempool
+	txs, err = exec.GetTxs(context.Background())
+	require.NoError(t, err)
+	require.Len(t, txs, 1)
+	require.NotContains(t, txs, tx1)
+	require.Contains(t, txs, tx2)
 }


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

Original implementation of `DummyExecutor` incorrectly removed transaction from "mempool" (in-memory slice in this case) during `GetTxs`.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced transaction management in the dummy executor.
	- Improved tracking of executed transactions.

- **Tests**
	- Added a new test for verifying transaction removal functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->